### PR TITLE
init: Add 100ms delay for bootloader startup

### DIFF
--- a/init.c
+++ b/init.c
@@ -317,6 +317,7 @@ static int gpio_sequence(struct port_interface *port, const char *seq, size_t le
 		free(to_free);
 	}
 #endif
+	usleep(100000);
 	fprintf(diag, "GPIO sequence end\n\n");
 	return ret;
 }


### PR DESCRIPTION
Most STM32 micros require a minimum startup time befote the bootloader is ready to start detection phase (see AN2606 rev 62, section 85.1).

Commit efeab9 was supposed to add some flexibility in the control of delays in GPIO sequences, however it also introduced a breaking change by removing an existing 100+500ms delay after the GPIO sequence:

- Before that commit, a delay of 100ms was added after each GPIO action (including the last one). After the commit, a delay of 100ms is added between actions, but not after the last one.
- An additional 500ms delay after the GPIO sequence was also removed.

As a result, all uses of stm32flash involving GPIO sequences may need to be modified to explicitly introduce additional delays.

Fix this by adding back a delay after the GPIO sequence completes.

Instead of using the 100+500ms of the original code, use a 100ms delay, which should be enough for most cases. According to AN2606 (table 191), there are only 6 cases where the bootloader startup time is greater than 100ms but less than 600ms.